### PR TITLE
Add option to use_umd driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
   'tt_tools_common>=1.4.19',
   'pyluwen>=0.7.11',
+  'tt_umd @ git+https://github.com/tenstorrent/tt-umd.git@brosko/more_py_api2',
   "tomli == 2.0.1; python_version < '3.11'",
   "jsons == 1.6.3",
 

--- a/tt_burnin/chip.py
+++ b/tt_burnin/chip.py
@@ -13,11 +13,28 @@ from pyluwen import PciChip, Telemetry
 from pyluwen import detect_chips as luwen_detect_chips
 from pyluwen import detect_chips_fallible as luwen_detect_chips_fallible
 
+from tt_umd import (
+    TTDevice,
+    TelemetryTag,
+    ARCH,
+    wormhole,
+    SmBusArcTelemetryReader,
+    SocDescriptor,
+    CoreType,
+)
 
 class TTChip:
-    def __init__(self, chip: PciChip):
-        self.luwen_chip = chip
-        self.interface_id = chip.pci_interface_id()
+    def __init__(self, chip: Union[PciChip, TTDevice]):
+        self.use_umd = isinstance(chip, TTDevice)
+        if self.use_umd:
+            self.umd_device = chip
+            self.interface_id = chip.get_pci_device().get_device_num()
+            self.soc_desc = SocDescriptor(self.umd_device)
+            # For UMD: ethernet coordinates (set externally)
+            self.eth_coord = None
+        else:
+            self.luwen_chip = chip
+            self.interface_id = chip.pci_interface_id()
 
         self._harvesting_bits = None
 
@@ -29,49 +46,145 @@ class TTChip:
     def arch(self) -> str: ...
 
     def reinit(self, callback=None):
-        self.luwen_chip = PciChip(self.interface_id)
-        self.telmetry_cache = None
+        if self.use_umd:
+            self.umd_device = TTDevice.create(self.interface_id)
+            self.umd_device.init_tt_device()
+            self.telmetry_cache = None
+            self.soc_desc = SocDescriptor(self.umd_device)
+        else:
+            self.luwen_chip = PciChip(self.interface_id)
+            self.telmetry_cache = None
 
-        chip_count = 0
-        block_count = 0
-        last_draw = time.time()
+            chip_count = 0
+            block_count = 0
+            last_draw = time.time()
 
-        def chip_detect_callback(status):
-            nonlocal chip_count, last_draw, block_count
+            def chip_detect_callback(status):
+                nonlocal chip_count, last_draw, block_count
 
-            if status.new_chip():
-                chip_count += 1
-            elif status.correct_down():
-                chip_count -= 1
-            chip_count = max(chip_count, 0)
+                if status.new_chip():
+                    chip_count += 1
+                elif status.correct_down():
+                    chip_count -= 1
+                chip_count = max(chip_count, 0)
 
-            if sys.stdout.isatty():
-                current_time = time.time()
-                if current_time - last_draw > 0.1:
-                    last_draw = current_time
+                if sys.stdout.isatty():
+                    current_time = time.time()
+                    if current_time - last_draw > 0.1:
+                        last_draw = current_time
 
-                    if block_count > 0:
-                        print(f"\033[{block_count}A", end="", flush=True)
-                        print("\033[J", end="", flush=True)
+                        if block_count > 0:
+                            print(f"\033[{block_count}A", end="", flush=True)
+                            print("\033[J", end="", flush=True)
 
-                    print(f"\rDetected Chips: {chip_count}\n", end="", flush=True)
-                    block_count = 1
+                        print(f"\rDetected Chips: {chip_count}\n", end="", flush=True)
+                        block_count = 1
 
-                    status_string = status.status_string()
-                    if status_string is not None:
-                        for line in status_string.splitlines():
-                            block_count += 1
-                            print(f"\r{line}", flush=True)
+                        status_string = status.status_string()
+                        if status_string is not None:
+                            for line in status_string.splitlines():
+                                block_count += 1
+                                print(f"\r{line}", flush=True)
+                else:
+                    time.sleep(0.01)
+
+            self.luwen_chip.init(
+                callback=chip_detect_callback if callback is None else callback
+            )
+
+    def get_telemetry(self):
+        if self.use_umd:
+            # For UMD, return a telemetry-like object with the required fields
+            arch = self.umd_device.get_arch()
+            
+            # Create the appropriate telemetry reader based on architecture
+            if arch == ARCH.WORMHOLE_B0:
+                telem_reader = SmBusArcTelemetryReader(self.umd_device)
             else:
-                time.sleep(0.01)
-
-        self.luwen_chip.init(
-            callback=chip_detect_callback if callback is None else callback
-        )
-
-    def get_telemetry(self) -> Telemetry:
-        self.telmetry_cache = self.luwen_chip.get_telemetry()
-        return self.telmetry_cache
+                telem_reader = self.umd_device.get_arc_telemetry_reader()
+            
+            # Create a simple telemetry object with the fields we need
+            class UMDTelemetry:
+                def __init__(self, reader, arch, device):
+                    self.reader = reader
+                    self.arch = arch
+                    self.device = device
+                    # Initialize telemetry fields
+                    self.m3_app_fw_version = None
+                    self.arc1_fw_version = None
+                    self.arc0_fw_version = None
+                    self.asic_location = None
+                    self.fw_bundle_version = None
+                    self.board_id = None
+                    # Common telemetry fields used in utils.py
+                    self.tdc = None
+                    self.vcore = None
+                    self.aiclk = None
+                    self.tdp = None
+                    self.asic_temperature = None
+                    self.vdd_limits = None
+                    self.thm_limits = None
+                    
+                def get_field(self, tag):
+                    if self.reader.is_entry_available(tag):
+                        return self.reader.read_entry(tag)
+                    return None
+            
+            # Map telemetry fields based on architecture
+            if arch == ARCH.WORMHOLE_B0:
+                telem_obj = UMDTelemetry(telem_reader, arch, self.umd_device)
+                # Map wormhole-specific fields
+                telem_obj.m3_app_fw_version = telem_obj.get_field(wormhole.TelemetryTag.M3_APP_FW_VERSION)
+                telem_obj.arc1_fw_version = telem_obj.get_field(wormhole.TelemetryTag.ARC1_FW_VERSION)
+                telem_obj.arc0_fw_version = telem_obj.get_field(wormhole.TelemetryTag.ARC0_FW_VERSION)
+                telem_obj.asic_location = telem_obj.get_field(wormhole.TelemetryTag.ASIC_RO)
+                telem_obj.fw_bundle_version = telem_obj.get_field(wormhole.TelemetryTag.FW_BUNDLE_VERSION)
+                # Get board_id from telemetry tags
+                board_id_high = telem_obj.get_field(wormhole.TelemetryTag.BOARD_ID_HIGH)
+                board_id_low = telem_obj.get_field(wormhole.TelemetryTag.BOARD_ID_LOW)
+                if board_id_high is not None and board_id_low is not None:
+                    telem_obj.board_id = (board_id_high << 32) | board_id_low
+                else:
+                    # Fallback to device method
+                    telem_obj.board_id = self.umd_device.get_board_id()
+                # Common telemetry fields used in utils.py
+                telem_obj.tdc = telem_obj.get_field(wormhole.TelemetryTag.TDC)
+                telem_obj.vcore = telem_obj.get_field(wormhole.TelemetryTag.VCORE)
+                telem_obj.aiclk = telem_obj.get_field(wormhole.TelemetryTag.AICLK)
+                telem_obj.tdp = telem_obj.get_field(wormhole.TelemetryTag.TDP)
+                telem_obj.asic_temperature = telem_obj.get_field(wormhole.TelemetryTag.ASIC_TEMPERATURE)
+                telem_obj.vdd_limits = telem_obj.get_field(wormhole.TelemetryTag.VDD_LIMITS)
+                telem_obj.thm_limits = telem_obj.get_field(wormhole.TelemetryTag.THM_LIMITS)
+            else:
+                telem_obj = UMDTelemetry(telem_reader, arch, self.umd_device)
+                # Map universal fields
+                telem_obj.asic_location = telem_obj.get_field(TelemetryTag.HARVESTING_STATE)
+                telem_obj.fw_bundle_version = telem_obj.get_field(TelemetryTag.FLASH_BUNDLE_VERSION)
+                # Get board_id from telemetry tags
+                board_id_high = telem_obj.get_field(TelemetryTag.BOARD_ID_HIGH)
+                board_id_low = telem_obj.get_field(TelemetryTag.BOARD_ID_LOW)
+                if board_id_high is not None and board_id_low is not None:
+                    telem_obj.board_id = (board_id_high << 32) | board_id_low
+                else:
+                    # Fallback to device method
+                    telem_obj.board_id = self.umd_device.get_board_id()
+                # Common telemetry fields used in utils.py
+                telem_obj.tdc = telem_obj.get_field(TelemetryTag.TDC)
+                telem_obj.vcore = telem_obj.get_field(TelemetryTag.VCORE)
+                telem_obj.aiclk = telem_obj.get_field(TelemetryTag.AICLK)
+                telem_obj.tdp = telem_obj.get_field(TelemetryTag.TDP)
+                telem_obj.asic_temperature = telem_obj.get_field(TelemetryTag.ASIC_TEMPERATURE)
+                telem_obj.vdd_limits = telem_obj.get_field(TelemetryTag.VDD_LIMITS)
+                telem_obj.thm_limits = telem_obj.get_field(TelemetryTag.THM_LIMITS)
+                # Fields only available in new telemetry format
+                telem_obj.noc_translation_enabled = telem_obj.get_field(TelemetryTag.NOC_TRANSLATION)
+                telem_obj.tensix_enabled_col = telem_obj.get_field(TelemetryTag.ENABLED_TENSIX_COL)
+            
+            self.telmetry_cache = telem_obj
+            return self.telmetry_cache
+        else:
+            self.telmetry_cache = self.luwen_chip.get_telemetry()
+            return self.telmetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
         if self.telmetry_cache is None:
@@ -107,29 +220,65 @@ class TTChip:
         return self.__vnum_to_version(telem.smbus_tx_arc0_fw_version)
 
     def board_type(self):
-        return self.luwen_chip.pci_board_type()
+        if self.use_umd:
+            return (self.umd_device.get_board_id() >> 36) & 0xFFFFF
+        else:
+            return self.luwen_chip.pci_board_type()
 
     def board_id(self):
         telem = self.get_telemetry_unchanged()
         return telem.board_id
 
     def noc_read(self, noc: int, x: int, y: int, addr: int, data: bytes):
-        self.luwen_chip.noc_read(noc, x, y, addr, data)
+        if self.use_umd:
+            if (noc != 0):
+                raise ValueError("UMD NOC must be 0")
+            read_data = self.umd_device.noc_read(x, y, addr, len(data))
+            data[:] = read_data
+        else:
+            self.luwen_chip.noc_read(noc, x, y, addr, data)
 
     def noc_read32(self, noc: int, x: int, y: int, addr: int):
-        return self.luwen_chip.noc_read32(noc, x, y, addr)
+        if self.use_umd:
+            if (noc != 0):
+                raise ValueError("UMD NOC must be 0")
+            return self.umd_device.noc_read32(x, y, addr)
+        else:
+            return self.luwen_chip.noc_read32(noc, x, y, addr)
 
     def noc_write(self, noc: int, x: int, y: int, addr: int, data: bytes):
-        self.luwen_chip.noc_write(noc, x, y, addr, data)
+        if self.use_umd:
+            if (noc != 0):
+                raise ValueError("UMD NOC must be 0")
+            self.umd_device.noc_write(x, y, addr, data)
+        else:
+            self.luwen_chip.noc_write(noc, x, y, addr, data)
 
     def noc_write32(self, noc: int, x: int, y: int, addr: int, data: int):
-        self.luwen_chip.noc_write32(noc, x, y, addr, data)
+        if self.use_umd:
+            if (noc != 0):
+                raise ValueError("UMD NOC must be 0")
+            self.umd_device.noc_write32(x, y, addr, data)
+        else:
+            self.luwen_chip.noc_write32(noc, x, y, addr, data)
 
     def noc_broadcast(self, noc: int, addr: int, data: bytes):
-        self.luwen_chip.noc_broadcast(noc, addr, data)
+        if self.use_umd:
+            if (noc != 0):
+                raise ValueError("UMD NOC must be 0")
+            for core in self.soc_desc.get_cores(CoreType.TENSIX):
+                self.umd_device.noc_write(core.x, core.y, addr, data)
+        else:
+            self.luwen_chip.noc_broadcast(noc, addr, data)
 
     def noc_broadcast32(self, noc: int, addr: int, data: int):
-        self.luwen_chip.noc_broadcast32(noc, addr, data)
+        if self.use_umd:
+            if (noc != 0):
+                raise ValueError("UMD NOC must be 0")
+            for core in self.soc_desc.get_cores(CoreType.TENSIX):
+                self.umd_device.noc_write32(core.x, core.y, addr, data)
+        else:
+            self.luwen_chip.noc_broadcast32(noc, addr, data)
 
     def axi_write32(self, addr: int, value: int):
         self.luwen_chip.axi_write32(addr, value)
@@ -147,7 +296,13 @@ class TTChip:
         return bytes(data)
 
     def arc_msg(self, *args, **kwargs):
-        return self.luwen_chip.arc_msg(*args, **kwargs)
+        if self.use_umd:
+            # UMD arc_msg returns a vector where first element is the exit code and the following are the results.
+            # To match the pyluwen format, we return [first result, exit code]
+            result = self.umd_device.arc_msg(*args, **kwargs)
+            return [result[1], result[0]]
+        else:
+            return self.luwen_chip.arc_msg(*args, **kwargs)
 
     # Given non-negative integer x, return an iterable containing the bits set in x, in increasing order.
     def _int_to_bits(self, x):
@@ -231,8 +386,13 @@ class BhChip(TTChip):
         return set(good_cores)
 
     def coord(self):
-        coord = self.luwen_chip.get_local_coord()
-        return (coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y)
+        if self.use_umd:
+            if self.eth_coord is None:
+                return "N/A"
+            return (self.eth_coord.x, self.eth_coord.y, self.eth_coord.rack, self.eth_coord.shelf)
+        else:
+            coord = self.luwen_chip.get_local_coord()
+            return (coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y)
 
     def arch(self):
         return "Blackhole"
@@ -286,8 +446,13 @@ class WhChip(TTChip):
         return f"Wormhole[{self.interface_id}]"
 
     def coord(self):
-        coord = self.luwen_chip.get_local_coord()
-        return (coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y)
+        if self.use_umd:
+            if self.eth_coord is None:
+                return "N/A"
+            return (self.eth_coord.x, self.eth_coord.y, self.eth_coord.rack, self.eth_coord.shelf)
+        else:
+            coord = self.luwen_chip.get_local_coord()
+            return (coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y)
 
 
 class RemoteWhChip(WhChip):

--- a/tt_burnin/chip.py
+++ b/tt_burnin/chip.py
@@ -75,7 +75,7 @@ class TTChip:
 
     def get_telemetry_unchanged(self) -> Telemetry:
         if self.telmetry_cache is None:
-            self.telmetry_cache = self.luwen_chip.get_telemetry()
+            self.get_telemetry()
 
         return self.telmetry_cache
 

--- a/tt_burnin/main.py
+++ b/tt_burnin/main.py
@@ -69,8 +69,8 @@ def reset_all_devices(devices, reset_filename=None):
         # reset all boards
         dev_ids = []
         for device in devices:
-            if not device.is_remote():
-                dev_ids.append(device.get_pci_interface_id())
+            if not device.is_remote:
+                dev_ids.append(device.interface_id)
         pci_board_reset(dev_ids, reinit=True)
 
 
@@ -306,7 +306,7 @@ def main():
         devices.append(device)
     print_all_available_devices(devs)
     if not args.no_reset:
-        reset_all_devices(devices, reset_filename=args.reset)
+        reset_all_devices(devs, reset_filename=args.reset)
 
     try:
         print()
@@ -345,13 +345,13 @@ def main():
         )
 
         # Create a live update for telemetry widget
-        with Live(Group(generate_table(devices), text), refresh_per_second=10) as live:
+        with Live(Group(generate_table(devs), text), refresh_per_second=10) as live:
             while True:
                 # Break if there is any user keypress
                 c = sys.stdin.read(1)
                 if len(c) > 0:
                     break
-                live.update(Group(generate_table(devices), text))
+                live.update(Group(generate_table(devs), text))
                 time.sleep(0.1)
     except Exception as e:
         import traceback
@@ -386,4 +386,4 @@ def main():
 
         # Final reset to restore state
         if not args.no_reset:
-            reset_all_devices(devices, reset_filename=args.reset)
+            reset_all_devices(devs, reset_filename=args.reset)

--- a/tt_burnin/utils.py
+++ b/tt_burnin/utils.py
@@ -24,7 +24,7 @@ from pyluwen import (
     run_wh_ubb_ipmi_reset,
     run_ubb_wait_for_driver_load
 )
-from tt_burnin.chip import RemoteWhChip, WhChip
+from tt_burnin.chip import RemoteWhChip, WhChip, BhChip
 
 
 def pci_board_reset(list_of_boards: List[int], reinit=False):
@@ -164,13 +164,12 @@ def print_all_available_devices(devices):
     table.add_column("Board Number")
     table.add_column("Coordinates")
     for i, device in enumerate(devices):
-        chip = device.luwen_chip
         board_id = hex(device.board_id()).replace("0x", "")
         board_type = get_board_type(board_id)
         device_series = device.arch()
         pci_dev_id = device.interface_id if not device.is_remote else "N/A"
         coords = device.coord()
-        if isinstance(chip, WhChip):
+        if isinstance(device, RemoteWhChip):
             suffix = " R" if device.is_remote else " L"
             board_type = board_type + suffix
 
@@ -240,7 +239,7 @@ def prefix_color_picker(current_value, max_value):
 
 def asic_temperature_parser(temp, dev):
     """ASIC temperature is reported with different schema for BH vs other chips"""
-    if dev.as_bh():
+    if isinstance(dev, BhChip):
         # BH temp is reported as signed 16_16 integer that needs to be split into two 16 bit values
         return (temp >> 16) + (temp & 0xFFFF) / 65536.0
     else:


### PR DESCRIPTION
Related issue: https://github.com/tenstorrent/tt-umd/issues/1432
This PR is an introductory PR to UMD in tt-burnin.

The change introduces --use_umd flag, which would turn on using UMD instead of pyluwen for all of the functionality.
tt-umd doesn't support Grayskull so this won't be available with UMD flag.

Changes:
- Consume tt_umd package
- Reset through umd
- IO and telemetry through umd

Testing:
Tested on N150 and P150, to be retested on all configurations

There are many relevant UMD PRs to enable this, and this change will switch to main branch once those are merged to UMD main.