### PR TITLE
Remove setting RUST_BACKTRACE to full

### DIFF
--- a/tt_burnin/main.py
+++ b/tt_burnin/main.py
@@ -275,7 +275,8 @@ def garbage_collect_all_devices(all_devices):
 
 def main():
     args = parse_args()
-    os.environ["RUST_BACKTRACE"] = "full"
+    # Uncomment the below to display a full Rust backtrace on error
+    # os.environ["RUST_BACKTRACE"] = "full"
     # Allow non blocking read for accepting user input before stopping burnin
     os.set_blocking(sys.stdin.fileno(), False)
     devs, devices = detect_and_group_devices()

--- a/tt_burnin/utils.py
+++ b/tt_burnin/utils.py
@@ -56,9 +56,6 @@ def pci_board_reset(list_of_boards: List[int], reinit=False):
         BHChipReset().full_lds_reset(pci_interfaces=reset_bh_pci_idx, silent=True)
 
     if reinit:
-        # Enable backtrace for debugging
-        os.environ["RUST_BACKTRACE"] = "full"
-
         print(
             CMD_LINE_COLOR.PURPLE,
             f"Re-initializing boards after reset....",


### PR DESCRIPTION
The justification for this is users don't need to see the full backtrace as it usually doesn't contain any more useful or actionable information.

It can be manually set by anyone who wants to see it.