### PR TITLE
Introduce usage of umd as backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
   'tt_tools_common~=1.5',
   'pyluwen~=0.8.0',
+  'tt_umd==0.9.5',
   "tomli == 2.0.1; python_version < '3.11'",
   "jsons == 1.6.3",
 

--- a/tt_burnin/chip.py
+++ b/tt_burnin/chip.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import time
-from typing import Union
+from typing import Optional, Union
 import itertools
 import sys
 
@@ -13,20 +13,30 @@ from pyluwen import PciChip, Telemetry
 from pyluwen import detect_chips as luwen_detect_chips
 from pyluwen import detect_chips_fallible as luwen_detect_chips_fallible
 
+from tt_umd import TTDevice, TelemetryTag, TopologyDiscoveryOptions, TopologyDiscovery, EthCoord
 
 class TTChip:
-    def __init__(self, chip: PciChip):
+    def __init__(self, chip: Union[PciChip, TTDevice], eth_coord: EthCoord = None):
+        self.use_luwen = isinstance(chip, PciChip)
         self.chip = chip
         
-        if chip.as_wh() is not None:
-            self.luwen_chip = chip.as_wh()
-        elif chip.as_bh() is not None:
-            self.luwen_chip = chip.as_bh()
+        if self.use_luwen:
+            if chip.as_wh() is not None:
+                self.luwen_chip = chip.as_wh()
+            elif chip.as_bh() is not None:
+                self.luwen_chip = chip.as_bh()
+            else:
+                raise ValueError("Did not recognize board")
+            luwen_eth_coord = self.luwen_chip.get_local_coord()
+            self.eth_coord = (luwen_eth_coord.shelf_x, luwen_eth_coord.shelf_y, luwen_eth_coord.rack_x, luwen_eth_coord.rack_y)
+            self.interface_id = self.luwen_chip.pci_interface_id()
         else:
-            raise ValueError("Did not recognize board")
-        luwen_eth_coord = self.luwen_chip.get_local_coord()
-        self.eth_coord = (luwen_eth_coord.shelf_x, luwen_eth_coord.shelf_y, luwen_eth_coord.rack_x, luwen_eth_coord.rack_y)
-        self.interface_id = self.luwen_chip.pci_interface_id()
+            if eth_coord is None:
+                self.eth_coord = (0, 0, 0, 0)
+            else:
+                # For UMD, we need to explicitly pass the ETH coord since it is not available through the same API as Luwen.
+                self.eth_coord = (eth_coord.x, eth_coord.y, eth_coord.rack, eth_coord.shelf)
+            self.interface_id = chip.get_pci_interface_id()
 
         self._harvesting_bits = None
 
@@ -37,8 +47,38 @@ class TTChip:
     @abstractmethod
     def arch(self) -> str: ...
 
-    def get_telemetry(self) -> Telemetry:
-        self.telemetry_cache = self.chip.get_telemetry()
+    def get_telemetry(self):
+        if self.use_luwen:
+            self.telemetry_cache = self.chip.get_telemetry()
+            return self.telemetry_cache
+
+        # Create a simple telemetry object with the fields we need
+        class UMDTelemetry:
+            def __init__(self, reader, arch):
+                self.reader = reader
+                self.arch = arch
+                # Initialize telemetry fields
+                self.m3_app_fw_version = None
+                self.asic_location = None
+                self.fw_bundle_version = None
+                self.board_id = None
+                self.noc_translation_enabled = None
+                
+            def get_field(self, tag):
+                if self.reader.is_entry_available(tag):
+                    return self.reader.read_entry(tag)
+                return None
+            
+        telem_obj = UMDTelemetry(self.chip.get_arc_telemetry_reader(), self.chip.get_arch())
+
+        telem_obj.m3_app_fw_version = telem_obj.get_field(TelemetryTag.DM_APP_FW_VERSION)
+        telem_obj.asic_location = telem_obj.get_field(TelemetryTag.ASIC_LOCATION)
+        telem_obj.fw_bundle_version = telem_obj.get_field(TelemetryTag.FLASH_BUNDLE_VERSION)
+        telem_obj.board_id = self.chip.get_board_id()
+        telem_obj.noc_translation_enabled = self.chip.get_noc_translation_enabled()
+        telem_obj.tensix_enabled_col = telem_obj.get_field(TelemetryTag.ENABLED_TENSIX_COL)
+
+        self.telemetry_cache = telem_obj
         return self.telemetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
@@ -88,7 +128,11 @@ class TTChip:
         self.chip.noc_broadcast32(noc, addr, data)
 
     def arc_msg(self, *args, **kwargs):
-        return self.chip.arc_msg(*args, **kwargs)
+        if self.use_luwen:
+            return self.chip.arc_msg(*args, **kwargs)
+        else:
+            # Note: UMD returns exit code as the first item, so eat this up and return the rest of the data as the response.
+            return self.chip.arc_msg(*args, **kwargs)[1:]
 
     # Given non-negative integer x, return an iterable containing the bits set in x, in increasing order.
     def _int_to_bits(self, x):
@@ -238,7 +282,7 @@ class RemoteWhChip(WhChip):
             self.chip.noc_write32(noc, *core, addr, data)
 
 
-def detect_local_chips(ignore_ethernet: bool = False) -> list[Union[WhChip, BhChip]]:
+def detect_local_chips(ignore_ethernet: bool = False, use_luwen: bool = True) -> list[Union[WhChip, BhChip]]:
     """
     This will create a chip which only gaurentees that you have communication with the chip.
     """
@@ -277,39 +321,54 @@ def detect_local_chips(ignore_ethernet: bool = False) -> list[Union[WhChip, BhCh
             time.sleep(0.01)
 
     output = []
-    for device in luwen_detect_chips_fallible(
-        local_only=True,
-        continue_on_failure=False,
-        callback=chip_detect_callback,
-        noc_safe=ignore_ethernet,
-    ):
-        if not device.have_comms():
-            raise Exception(
-                f"Do not have communication with {device}, you should reset or remove this device from your system before continuing."
-            )
+    devices = []
+    if use_luwen:
+        devices = dict(enumerate(luwen_detect_chips_fallible(
+            local_only=True,
+            continue_on_failure=False,
+            callback=chip_detect_callback,
+            noc_safe=ignore_ethernet,
+        )))
+    else:
+        options = TopologyDiscoveryOptions()
+        options.wait_on_ethernet_link_training = not ignore_ethernet
+        options.discover_remote_devices = not ignore_ethernet
+        _, devices = TopologyDiscovery.discover(options)
+    for idx, device in devices.items():
+        if use_luwen:
+            if not device.have_comms():
+                raise Exception(
+                    f"Do not have communication with {device}, you should reset or remove this device from your system before continuing."
+                )
 
-        device = device.force_upgrade()
+            device = device.force_upgrade()
 
         if device.as_wh() is not None:
-            output.append(WhChip(device.as_wh()))
+            output.append(WhChip(device))
         elif device.as_bh() is not None:
-            output.append(BhChip(device.as_bh()))
+            output.append(BhChip(device))
         else:
             raise ValueError("Did not recognize board")
 
     return output
 
 
-def detect_chips(local_only: bool = False) -> list[Union[WhChip, BhChip]]:
-    output = []
-    for device in luwen_detect_chips(local_only=local_only):
+def detect_chips(local_only: bool = False, use_luwen: bool = False) -> list[Union[WhChip, BhChip]]:
+    output = []   
+    
+    if use_luwen:
+        devices = dict(enumerate(luwen_detect_chips(local_only=local_only)))
+    else:
+        options = TopologyDiscoveryOptions()
+        options.wait_on_ethernet_link_training = not local_only
+        options.discover_remote_devices = not local_only
+        _, devices = TopologyDiscovery.discover(options)
+    
+    for _, device in devices.items():
         if device.as_wh() is not None:
-            if device.is_remote():
-                output.append(RemoteWhChip(device.as_wh()))
-            else:
-                output.append(WhChip(device.as_wh()))
+            output.append(WhChip(device))
         elif device.as_bh() is not None:
-            output.append(BhChip(device.as_bh()))
+            output.append(BhChip(device))
         else:
             raise ValueError("Did not recognize board")
 

--- a/tt_burnin/chip.py
+++ b/tt_burnin/chip.py
@@ -28,47 +28,6 @@ class TTChip:
     @abstractmethod
     def arch(self) -> str: ...
 
-    def reinit(self, callback=None):
-        self.luwen_chip = PciChip(self.interface_id)
-        self.telmetry_cache = None
-
-        chip_count = 0
-        block_count = 0
-        last_draw = time.time()
-
-        def chip_detect_callback(status):
-            nonlocal chip_count, last_draw, block_count
-
-            if status.new_chip():
-                chip_count += 1
-            elif status.correct_down():
-                chip_count -= 1
-            chip_count = max(chip_count, 0)
-
-            if sys.stdout.isatty():
-                current_time = time.time()
-                if current_time - last_draw > 0.1:
-                    last_draw = current_time
-
-                    if block_count > 0:
-                        print(f"\033[{block_count}A", end="", flush=True)
-                        print("\033[J", end="", flush=True)
-
-                    print(f"\rDetected Chips: {chip_count}\n", end="", flush=True)
-                    block_count = 1
-
-                    status_string = status.status_string()
-                    if status_string is not None:
-                        for line in status_string.splitlines():
-                            block_count += 1
-                            print(f"\r{line}", flush=True)
-            else:
-                time.sleep(0.01)
-
-        self.luwen_chip.init(
-            callback=chip_detect_callback if callback is None else callback
-        )
-
     def get_telemetry(self) -> Telemetry:
         self.telmetry_cache = self.luwen_chip.get_telemetry()
         return self.telmetry_cache
@@ -94,18 +53,6 @@ class TTChip:
             version & 0xFF,
         )
 
-    def m3_fw_app_version(self):
-        telem = self.get_telemetry_unchanged()
-        return self.__vnum_to_version(telem.smbus_tx_m3_app_fw_version)
-
-    def smbus_fw_version(self):
-        telem = self.get_telemetry_unchanged()
-        return self.__vnum_to_version(telem.smbus_tx_arc1_fw_version)
-
-    def arc_l2_fw_version(self):
-        telem = self.get_telemetry_unchanged()
-        return self.__vnum_to_version(telem.smbus_tx_arc0_fw_version)
-
     def board_type(self):
         return self.luwen_chip.pci_board_type()
 
@@ -130,30 +77,6 @@ class TTChip:
 
     def noc_broadcast32(self, noc: int, addr: int, data: int):
         self.luwen_chip.noc_broadcast32(noc, addr, data)
-
-    def axi_write32(self, addr: int, value: int):
-        self.luwen_chip.axi_write32(addr, value)
-
-    def axi_write(self, addr: int, data: bytes):
-        self.luwen_chip.axi_write(addr, data)
-
-    def axi_read32(self, addr: int) -> int:
-        return self.luwen_chip.axi_read32(addr)
-
-    def axi_read(self, addr: int, size: int) -> bytes:
-        data = bytearray(size)
-        self.luwen_chip.axi_read(addr, data)
-
-        return bytes(data)
-
-    def spi_write(self, addr: int, data: bytes):
-        self.luwen_chip.spi_write(addr, data)
-
-    def spi_read(self, addr: int, size: int) -> bytes:
-        data = bytearray(size)
-        self.luwen_chip.spi_read(addr, data)
-
-        return bytes(data)
 
     def arc_msg(self, *args, **kwargs):
         return self.luwen_chip.arc_msg(*args, **kwargs)

--- a/tt_burnin/chip.py
+++ b/tt_burnin/chip.py
@@ -21,7 +21,7 @@ class TTChip:
 
         self._harvesting_bits = None
 
-        self.telmetry_cache = None
+        self.telemetry_cache = None
 
         self.is_remote = False
 
@@ -29,14 +29,14 @@ class TTChip:
     def arch(self) -> str: ...
 
     def get_telemetry(self) -> Telemetry:
-        self.telmetry_cache = self.luwen_chip.get_telemetry()
-        return self.telmetry_cache
+        self.telemetry_cache = self.luwen_chip.get_telemetry()
+        return self.telemetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
-        if self.telmetry_cache is None:
-            self.telmetry_cache = self.luwen_chip.get_telemetry()
+        if self.telemetry_cache is None:
+            return self.get_telemetry()
 
-        return self.telmetry_cache
+        return self.telemetry_cache
 
     def get_harvest_bits(self) -> int:
         if self._harvesting_bits is None:

--- a/tt_burnin/chip.py
+++ b/tt_burnin/chip.py
@@ -16,8 +16,17 @@ from pyluwen import detect_chips_fallible as luwen_detect_chips_fallible
 
 class TTChip:
     def __init__(self, chip: PciChip):
-        self.luwen_chip = chip
-        self.interface_id = chip.pci_interface_id()
+        self.chip = chip
+        
+        if chip.as_wh() is not None:
+            self.luwen_chip = chip.as_wh()
+        elif chip.as_bh() is not None:
+            self.luwen_chip = chip.as_bh()
+        else:
+            raise ValueError("Did not recognize board")
+        luwen_eth_coord = self.luwen_chip.get_local_coord()
+        self.eth_coord = (luwen_eth_coord.shelf_x, luwen_eth_coord.shelf_y, luwen_eth_coord.rack_x, luwen_eth_coord.rack_y)
+        self.interface_id = self.luwen_chip.pci_interface_id()
 
         self._harvesting_bits = None
 
@@ -29,7 +38,7 @@ class TTChip:
     def arch(self) -> str: ...
 
     def get_telemetry(self) -> Telemetry:
-        self.telemetry_cache = self.luwen_chip.get_telemetry()
+        self.telemetry_cache = self.chip.get_telemetry()
         return self.telemetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
@@ -54,32 +63,32 @@ class TTChip:
         )
 
     def board_type(self):
-        return self.luwen_chip.pci_board_type()
+        return self.chip.pci_board_type()
 
     def board_id(self):
         telem = self.get_telemetry_unchanged()
         return telem.board_id
 
     def noc_read(self, noc: int, x: int, y: int, addr: int, data: bytes):
-        self.luwen_chip.noc_read(noc, x, y, addr, data)
+        self.chip.noc_read(noc, x, y, addr, data)
 
     def noc_read32(self, noc: int, x: int, y: int, addr: int):
-        return self.luwen_chip.noc_read32(noc, x, y, addr)
+        return self.chip.noc_read32(noc, x, y, addr)
 
     def noc_write(self, noc: int, x: int, y: int, addr: int, data: bytes):
-        self.luwen_chip.noc_write(noc, x, y, addr, data)
+        self.chip.noc_write(noc, x, y, addr, data)
 
     def noc_write32(self, noc: int, x: int, y: int, addr: int, data: int):
-        self.luwen_chip.noc_write32(noc, x, y, addr, data)
+        self.chip.noc_write32(noc, x, y, addr, data)
 
     def noc_broadcast(self, noc: int, addr: int, data: bytes):
-        self.luwen_chip.noc_broadcast(noc, addr, data)
+        self.chip.noc_broadcast(noc, addr, data)
 
     def noc_broadcast32(self, noc: int, addr: int, data: int):
-        self.luwen_chip.noc_broadcast32(noc, addr, data)
+        self.chip.noc_broadcast32(noc, addr, data)
 
     def arc_msg(self, *args, **kwargs):
-        return self.luwen_chip.arc_msg(*args, **kwargs)
+        return self.chip.arc_msg(*args, **kwargs)
 
     # Given non-negative integer x, return an iterable containing the bits set in x, in increasing order.
     def _int_to_bits(self, x):
@@ -162,10 +171,6 @@ class BhChip(TTChip):
 
         return set(good_cores)
 
-    def coord(self):
-        coord = self.luwen_chip.get_local_coord()
-        return (coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y)
-
     def arch(self):
         return "Blackhole"
 
@@ -217,10 +222,6 @@ class WhChip(TTChip):
     def __repr__(self):
         return f"Wormhole[{self.interface_id}]"
 
-    def coord(self):
-        coord = self.luwen_chip.get_local_coord()
-        return (coord.shelf_x, coord.shelf_y, coord.rack_x, coord.rack_y)
-
 
 class RemoteWhChip(WhChip):
     def __init__(self, *args, **kwargs):
@@ -230,11 +231,11 @@ class RemoteWhChip(WhChip):
 
     def noc_broadcast(self, noc: int, addr: int, data: bytes):
         for core in self.get_tensix_locations():
-            self.luwen_chip.noc_write(noc, *core, addr, data)
+            self.chip.noc_write(noc, *core, addr, data)
 
     def noc_broadcast32(self, noc: int, addr: int, data: int):
         for core in self.get_tensix_locations():
-            self.luwen_chip.noc_write32(noc, *core, addr, data)
+            self.chip.noc_write32(noc, *core, addr, data)
 
 
 def detect_local_chips(ignore_ethernet: bool = False) -> list[Union[WhChip, BhChip]]:

--- a/tt_burnin/main.py
+++ b/tt_burnin/main.py
@@ -39,7 +39,7 @@ from tt_tools_common.utils_common.tools_utils import (
 )
 
 
-def reset_all_devices(devices, reset_filename=None):
+def reset_all_devices(devices, reset_filename=None, use_luwen: bool = False):
     """Reset all devices"""
     print(CMD_LINE_COLOR.BLUE, "Resetting devices on host...", CMD_LINE_COLOR.ENDC)
     LOG_FOLDER = os.path.expanduser("~/.config/tenstorrent")
@@ -68,14 +68,14 @@ def reset_all_devices(devices, reset_filename=None):
         parsed_dict = mobo_reset_from_json(data)
         pci_indices, reinit = pci_indices_from_json(parsed_dict)
         if pci_indices:
-            pci_board_reset(pci_indices, reinit)
+            pci_board_reset(pci_indices, reinit, use_luwen=use_luwen)
     else:
         # reset all boards
         dev_ids = []
         for device in devices:
             if not device.is_remote():
                 dev_ids.append(device.get_pci_interface_id())
-        pci_board_reset(dev_ids, reinit=True)
+        pci_board_reset(dev_ids, reinit=True, use_luwen=use_luwen)
 
 
 def start_burnin_wh(
@@ -232,6 +232,12 @@ def parse_args():
         default=False,
         help="Don't load the power virus workload, just run the tensix idle",
     )
+    parser.add_argument(
+        "--use_luwen",
+        default=False,
+        action="store_true",
+        help="Use deprecated Luwen driver instead of UMD (default).",
+    )
     # subparsers = parser.add_subparsers(title="command", dest="command", required=True)
     return parser.parse_args()
 
@@ -282,7 +288,7 @@ def main():
     devs, devices = detect_and_group_devices()
     print_all_available_devices(devs)
     if not args.no_reset:
-        reset_all_devices(devices, reset_filename=args.reset)
+        reset_all_devices(devices, reset_filename=args.reset, use_luwen=args.use_luwen)
 
     # Force garbage collection on the old devices and start with new device objects after reset
     garbage_collect_all_devices(devices)
@@ -361,7 +367,7 @@ def main():
 
         # Final reset to restore state
         if not args.no_reset:
-            reset_all_devices(devices, reset_filename=args.reset)
+            reset_all_devices(devices, reset_filename=args.reset, use_luwen=args.use_luwen)
 
         # Force garbage collection on the old devices and start with new device objects after reset
         garbage_collect_all_devices(devices)

--- a/tt_burnin/main.py
+++ b/tt_burnin/main.py
@@ -38,6 +38,8 @@ from tt_tools_common.utils_common.tools_utils import (
     detect_chips_with_callback,
 )
 
+from tt_umd import TopologyDiscovery
+
 
 def reset_all_devices(devices, reset_filename=None, use_luwen: bool = False):
     """Reset all devices"""
@@ -241,18 +243,23 @@ def parse_args():
     # subparsers = parser.add_subparsers(title="command", dest="command", required=True)
     return parser.parse_args()
 
-def detect_and_group_devices():
-    all_devices = detect_chips_with_callback()
+def detect_and_group_devices(use_luwen: bool = False):
+    if use_luwen:
+        all_devices = dict(enumerate(detect_chips_with_callback()))
+        umd_cluster_descriptor = None
+    else:
+        umd_cluster_descriptor, all_devices = TopologyDiscovery.discover()
     devs = []
     devices = []
-    for device in all_devices:
+    for idx, device in all_devices.items():
         if device.as_wh() is not None:
+            eth_coord = umd_cluster_descriptor.get_chip_locations()[idx] if umd_cluster_descriptor else None
             if device.is_remote():
-                devs.append(RemoteWhChip(device.as_wh()))
+                devs.append(RemoteWhChip(device, eth_coord))
             else:
-                devs.append(WhChip(device.as_wh()))
+                devs.append(WhChip(device, eth_coord))
         elif device.as_bh() is not None:
-            devs.append(BhChip(device.as_bh()))
+            devs.append(BhChip(device))
         else:
             raise ValueError("Did not recognize board")
         devices.append(device)
@@ -262,7 +269,10 @@ def detect_and_group_devices():
         # Raise power state to high (BH)
         for device in devices:
             try:
-                device.set_power_state("high")
+                if use_luwen:
+                    device.set_power_state("high")
+                else:
+                    device.set_power_state(True)
             except:
                 print(
                     CMD_LINE_COLOR.RED,
@@ -285,14 +295,14 @@ def main():
     # os.environ["RUST_BACKTRACE"] = "full"
     # Allow non blocking read for accepting user input before stopping burnin
     os.set_blocking(sys.stdin.fileno(), False)
-    devs, devices = detect_and_group_devices()
+    devs, devices = detect_and_group_devices(args.use_luwen)
     print_all_available_devices(devs)
     if not args.no_reset:
         reset_all_devices(devices, reset_filename=args.reset, use_luwen=args.use_luwen)
 
     # Force garbage collection on the old devices and start with new device objects after reset
     garbage_collect_all_devices(devices)
-    devs, devices = detect_and_group_devices()
+    devs, devices = detect_and_group_devices(args.use_luwen)
     try:
         print()
         print(
@@ -328,13 +338,13 @@ def main():
         )
 
         # Create a live update for telemetry widget
-        with Live(Group(generate_table(devices), text), refresh_per_second=10) as live:
+        with Live(Group(generate_table(devices, args.use_luwen), text), refresh_per_second=10) as live:
             while True:
                 # Break if there is any user keypress
                 c = sys.stdin.read(1)
                 if len(c) > 0:
                     break
-                live.update(Group(generate_table(devices), text))
+                live.update(Group(generate_table(devices, args.use_luwen), text))
                 time.sleep(0.1)
     except Exception as e:
         import traceback

--- a/tt_burnin/utils.py
+++ b/tt_burnin/utils.py
@@ -145,18 +145,17 @@ def print_all_available_devices(devices):
     console = get_console()
     table = Table()
     table.add_column("Pci Dev ID")
-    table.add_column("Board Type")
     table.add_column("Device Series")
+    table.add_column("Board Type")
     table.add_column("Board Number")
     table.add_column("Coordinates")
     for i, device in enumerate(devices):
-        chip = device.luwen_chip
         board_id = hex(device.board_id()).replace("0x", "")
         board_type = get_board_type(board_id)
         device_series = device.arch()
         pci_dev_id = device.interface_id if not device.is_remote else "N/A"
-        coords = device.coord()
-        if isinstance(chip, WhChip):
+        coords = device.eth_coord
+        if isinstance(device, WhChip):
             suffix = " R" if device.is_remote else " L"
             board_type = board_type + suffix
 

--- a/tt_burnin/utils.py
+++ b/tt_burnin/utils.py
@@ -25,7 +25,7 @@ from pyluwen import (
 )
 from tt_burnin.chip import RemoteWhChip, WhChip
 
-from tt_umd import PCIDevice, WarmReset, TopologyDiscovery
+from tt_umd import PCIDevice, WarmReset, TopologyDiscovery, TelemetryTag
 
 
 def pci_board_reset(list_of_boards: List[int], reinit=False, use_luwen: bool = False):
@@ -255,9 +255,9 @@ def prefix_color_picker(current_value, max_value):
     else:
         return "[orange3]"
 
-def asic_temperature_parser(temp, dev):
+def asic_temperature_parser(temp, dev, use_luwen: bool = False):
     """ASIC temperature is reported with different schema for BH vs other chips"""
-    if dev.as_bh():
+    if dev.as_bh() or not use_luwen:
         # BH temp is reported as signed 16_16 integer that needs to be split into two 16 bit values
         return (temp >> 16) + (temp & 0xFFFF) / 65536.0
     else:
@@ -311,7 +311,7 @@ def reset_6u_glx():
         # Error out if chips don't initalize
     return
 
-def generate_table(devices) -> Table:
+def generate_table(devices, use_luwen: bool = False) -> Table:
     """Make a table to display telemetry values."""
     table = Table(
         title=" ",
@@ -324,14 +324,29 @@ def generate_table(devices) -> Table:
     table.add_column("Core Temp (°C)")
 
     for i, dev in enumerate(devices):
-        telem = jsons.dump(dev.get_telemetry())
+        if use_luwen:
+            telem = jsons.dump(dev.get_telemetry())
+        else:
+            # Note that with UMD backend we use the new telemetry reader for both WH and BH, so the table ends up being the same for both architectures. With Luwen we use the old telemetry reader for BH and the new one for WH, so the table ends up being different between architectures.
+            tel_reader = dev.get_arc_telemetry_reader()
+            telem = {}
+            telem["tdc"] = tel_reader.read_entry(TelemetryTag.TDC)
+            telem["vcore"] = tel_reader.read_entry(TelemetryTag.VCORE)
+            telem["aiclk"] = tel_reader.read_entry(TelemetryTag.AICLK)
+            telem["tdp"] = tel_reader.read_entry(TelemetryTag.TDP)
+            telem["asic_temperature"] = tel_reader.read_entry(TelemetryTag.ASIC_TEMPERATURE)
+            telem["vdd_limits"] = tel_reader.read_entry(TelemetryTag.VDD_LIMITS)
+            telem["tdc_limit_max"] = tel_reader.read_entry(TelemetryTag.TDC_LIMIT_MAX)
+            telem["aiclk_limit_max"] = tel_reader.read_entry(TelemetryTag.AICLK_LIMIT_MAX)
+            telem["tdp_limit_max"] = tel_reader.read_entry(TelemetryTag.TDP_LIMIT_MAX)
+            telem["thm_limits"] = tel_reader.read_entry(TelemetryTag.THM_LIMIT_SHUTDOWN)
         current = int(hex(telem["tdc"]), 16) & 0xFFFF
         voltage = int(hex(telem["vcore"]), 16) / 1000
         aiclk = int(hex(telem["aiclk"]), 16) & 0xFFFF
         power = int(hex(telem["tdp"]), 16) & 0xFFFF
-        asic_temperature = asic_temperature_parser(int(hex(telem["asic_temperature"]), 16), dev)
+        asic_temperature = asic_temperature_parser(int(hex(telem["asic_temperature"]), 16), dev, use_luwen)
         vdd_max = int(hex(telem["vdd_limits"]), 16) >> 16
-        if dev.as_bh():
+        if dev.as_bh() or not use_luwen:
             curr_limit = int(hex(telem["tdc_limit_max"]), 16)
             aiclk_limit = int(hex(telem["aiclk_limit_max"]), 16)
             pwr_limit = int(hex(telem["tdp_limit_max"]), 16)
@@ -341,7 +356,7 @@ def generate_table(devices) -> Table:
             pwr_limit = int(hex(telem["tdp"]), 16) >> 16
         thm_limit = int(hex(telem["thm_limits"]), 16) & 0xFFFF
         table.add_row(
-            f"{i}",
+            f"{i} {'R' if dev.is_remote() else 'L'}",
             f"{voltage:4.2f}[light_goldenrod1] / {vdd_max/1000:4.2f}",
             f"{prefix_color_picker(current, curr_limit)}{current:5.1f}[light_goldenrod1] / {curr_limit:5.1f}",
             f"{prefix_color_picker(aiclk, aiclk_limit)}{aiclk:4.0f}[light_goldenrod1] / {aiclk_limit:4.0f}",

--- a/tt_burnin/utils.py
+++ b/tt_burnin/utils.py
@@ -25,35 +25,52 @@ from pyluwen import (
 )
 from tt_burnin.chip import RemoteWhChip, WhChip
 
+from tt_umd import PCIDevice, WarmReset, TopologyDiscovery
 
-def pci_board_reset(list_of_boards: List[int], reinit=False):
+
+def pci_board_reset(list_of_boards: List[int], reinit=False, use_luwen: bool = False):
     """Given a list of pci index's init the pci chip and call reset on it"""
 
-    reset_wh_pci_idx = []
-    reset_bh_pci_idx = []
-    for pci_idx in list_of_boards:
-        try:
-            chip = PciChip(pci_interface=pci_idx)
-        except Exception as e:
-            print(
-                CMD_LINE_COLOR.RED,
-                f"Error accessing board at pci index {pci_idx}! Use -ls to see all devices available to reset",
-                CMD_LINE_COLOR.ENDC,
-            )
-        if chip.as_wh():
-            reset_wh_pci_idx.append(pci_idx)
-        elif chip.as_bh():
-            reset_bh_pci_idx.append(pci_idx)
-        else:
-            print(f"{CMD_LINE_COLOR.RED}Unknown chip!!{CMD_LINE_COLOR.ENDC}")
-            sys.exit(1)
+    if use_luwen:
+        reset_wh_pci_idx = []
+        reset_bh_pci_idx = []
+        for pci_idx in list_of_boards:
+            try:
+                chip = PciChip(pci_interface=pci_idx)
+            except Exception as e:
+                print(
+                    CMD_LINE_COLOR.RED,
+                    f"Error accessing board at pci index {pci_idx}! Use -ls to see all devices available to reset",
+                    CMD_LINE_COLOR.ENDC,
+                )
+            if chip.as_wh():
+                reset_wh_pci_idx.append(pci_idx)
+            elif chip.as_bh():
+                reset_bh_pci_idx.append(pci_idx)
+            else:
+                print(f"{CMD_LINE_COLOR.RED}Unknown chip!!{CMD_LINE_COLOR.ENDC}")
+                sys.exit(1)
 
-    # reset wh devices with pci indices
-    if len(reset_wh_pci_idx) > 0:
-        WHChipReset().full_lds_reset(pci_interfaces=reset_wh_pci_idx, silent=True)
+        # reset wh devices with pci indices
+        if len(reset_wh_pci_idx) > 0:
+            WHChipReset().full_lds_reset(pci_interfaces=reset_wh_pci_idx, silent=True)
 
-    if len(reset_bh_pci_idx) > 0:
-        BHChipReset().full_lds_reset(pci_interfaces=reset_bh_pci_idx, silent=True)
+        if len(reset_bh_pci_idx) > 0:
+            BHChipReset().full_lds_reset(pci_interfaces=reset_bh_pci_idx, silent=True)
+    else:
+        chips = PCIDevice.enumerate_devices_info()
+        reset_pci_idx = []
+        for pci_idx in list_of_boards:
+            if pci_idx not in chips:
+                print(
+                    CMD_LINE_COLOR.RED,
+                    f"Error accessing board at pci index {pci_idx}! Use -ls to see all devices available to reset",
+                    CMD_LINE_COLOR.ENDC,
+                )
+            else:
+                reset_pci_idx.append(pci_idx)
+        if len(reset_pci_idx) > 0:
+            WarmReset.warm_reset(reset_pci_idx)
 
     if reinit:
         print(
@@ -62,7 +79,10 @@ def pci_board_reset(list_of_boards: List[int], reinit=False):
             CMD_LINE_COLOR.ENDC,
         )
         try:
-            chips = detect_chips_with_callback()
+            if use_luwen:
+                _ = detect_chips_with_callback()
+            else:
+                _ = TopologyDiscovery.discover()
         except Exception as e:
             print(
                 CMD_LINE_COLOR.RED,


### PR DESCRIPTION
A rework of https://github.com/tenstorrent/tt-burnin/pull/31

Related issue: https://github.com/tenstorrent/tt-umd/issues/1432
This PR is an introductory PR to UMD in tt-burnin.

The change introduces --use_luwen flag, which would default back to using pyluwen as backend. UMD will be used by default.

Changes:

Consume tt_umd package
Reset through umd
IO and telemetry through umd
Minor fixes/changes for luwen path.
Testing:
Tested on N300 and P150, the output looks the same as with luwen.

This change will switch back to a specific version of UMD pulled from pypi, once the relevant PRs are merged